### PR TITLE
alterado o tempo de execução: evitar bloqueio no cloudflare

### DIFF
--- a/level_monitor_main.py
+++ b/level_monitor_main.py
@@ -1,7 +1,7 @@
 import asyncio
 from apps.level_monitor.service import monitor_level_ups
 
-LEVEL_INTERVAL = 390  # segundos
+LEVEL_INTERVAL = 900  # segundos
 
 async def loop_monitor_level_ups():
     print("Bot monitorando level ups.")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from core.config import settings
 from apps.deaths_monitor.service import monitor_deaths
 from apps.online_monitor.service import monitor_online
 
-CHECK_INTERVAL = 200
+CHECK_INTERVAL = 390
 
 async def main_loop():
     print("Bot monitorando mortes e players online.")


### PR DESCRIPTION
Ajustado o tempo de 6,5 minutos do up level para 15 minutos, e de 3 minutos para 6,5 o de mortes. Alternativa para evitar bloqueio cloudflare do URL.